### PR TITLE
fix dependency loading issue with embeddable associations

### DIFF
--- a/lib/reviewed/award.rb
+++ b/lib/reviewed/award.rb
@@ -1,4 +1,7 @@
+require 'reviewed/article'
+
 module Reviewed
   class Award < Base
+    has_many :articles
   end
 end

--- a/spec/article_spec.rb
+++ b/spec/article_spec.rb
@@ -16,27 +16,27 @@ describe Reviewed::Article, vcr: true do
     describe 'pages' do
 
       it 'has_many :pages' do
-        Reviewed::Article._embedded_many.should include({"pages"=>Reviewed::Page})
+        Reviewed::Article._embedded_many.should include({"pages"=>"Reviewed::Page"})
       end
     end
 
     describe 'deals' do
 
       it 'has_many :deals' do
-        Reviewed::Article._embedded_many.should include({"deals"=>Reviewed::Deal})
+        Reviewed::Article._embedded_many.should include({"deals"=>"Reviewed::Deal"})
       end
     end
 
     describe 'related_articles' do
       it 'has_many :related_articles' do
-        Reviewed::Article._embedded_many.should include({"related_articles"=>Reviewed::Article})
+        Reviewed::Article._embedded_many.should include({"related_articles"=>"Reviewed::Article"})
       end
     end
 
     describe 'products' do
 
       it 'has_many :products' do
-        Reviewed::Article._embedded_many.should include({"products"=>Reviewed::Product})
+        Reviewed::Article._embedded_many.should include({"products"=>"Reviewed::Product"})
       end
 
       it 'returns products of the correct class' do
@@ -49,7 +49,7 @@ describe Reviewed::Article, vcr: true do
     describe 'attachments' do
 
       it 'does not has_many :attachments' do
-        Reviewed::Article._embedded_many.should_not include({"attachments"=>Reviewed::Attachment})
+        Reviewed::Article._embedded_many.should_not include({"attachments"=>"Reviewed::Attachment"})
       end
 
       it 'gets gallery attachments' do

--- a/spec/award_spec.rb
+++ b/spec/award_spec.rb
@@ -1,4 +1,28 @@
 require 'spec_helper'
 
 describe Reviewed::Award do
+
+  let(:client) do
+    Reviewed::Client.new(api_key: TEST_KEY, base_uri: TEST_URL)
+  end
+
+  describe 'associations' do
+
+    describe 'articles', vcr: true do
+
+      before(:each) do
+        @award = client.awards.find('best-of-year')
+      end
+
+      it 'has_many :articles' do
+        Reviewed::Award._embedded_many.should include({"articles"=>"Reviewed::Article"})
+      end
+
+      it 'returns attachments of the correct class' do
+        @award.articles.each do |article|
+          article.should be_an_instance_of(Reviewed::Article)
+        end
+      end
+    end
+  end
 end

--- a/spec/embeddable_spec.rb
+++ b/spec/embeddable_spec.rb
@@ -35,16 +35,7 @@ describe Reviewed::Embeddable do
         it 'stores the correct embedded relationship' do
           Reviewed::MockEmbeddable._embedded_many.should be_empty
           Reviewed::MockEmbeddable.has_many("mock_embeddables")
-          Reviewed::MockEmbeddable._embedded_many.should eql([{ "mock_embeddables" => Reviewed::MockEmbeddable }])
-        end
-      end
-
-      context 'invalid name' do
-
-        it 'errors' do
-          expect {
-            Reviewed::MockEmbeddable.has_many("bad_name")
-          }.to raise_error
+          Reviewed::MockEmbeddable._embedded_many.should eql([{ "mock_embeddables" => "Reviewed::MockEmbeddable" }])
         end
       end
     end
@@ -54,7 +45,7 @@ describe Reviewed::Embeddable do
       it 'stores the correct embedded relationship' do
         Reviewed::MockEmbeddable._embedded_many.should be_empty
         Reviewed::MockEmbeddable.has_many("mock_embeddables", as: "test")
-        Reviewed::MockEmbeddable._embedded_many.should eql([{ "test" => Reviewed::MockEmbeddable }])
+        Reviewed::MockEmbeddable._embedded_many.should eql([{ "test" => "Reviewed::MockEmbeddable" }])
       end
     end
 
@@ -63,7 +54,7 @@ describe Reviewed::Embeddable do
       it 'stores the correct embedded relationship' do
         Reviewed::MockEmbeddable._embedded_many.should be_empty
         Reviewed::MockEmbeddable.has_many("mock_embeddables", class_name: "Reviewed::Article")
-        Reviewed::MockEmbeddable._embedded_many.should eql([{ "mock_embeddables" => Reviewed::Article }])
+        Reviewed::MockEmbeddable._embedded_many.should eql([{ "mock_embeddables" => "Reviewed::Article" }])
       end
     end
   end
@@ -73,7 +64,7 @@ describe Reviewed::Embeddable do
     it 'stores the correct embedded relationship' do
       Reviewed::MockEmbeddable._embedded_one.should be_empty
       Reviewed::MockEmbeddable.has_one("mock_embeddable")
-      Reviewed::MockEmbeddable._embedded_one.should eql([{ "mock_embeddable" => Reviewed::MockEmbeddable }])
+      Reviewed::MockEmbeddable._embedded_one.should eql([{ "mock_embeddable" => "Reviewed::MockEmbeddable" }])
     end
   end
 
@@ -98,7 +89,7 @@ describe Reviewed::Embeddable do
     let(:mocked) { Reviewed::MockEmbeddable.new }
 
     before(:each) do
-      Reviewed::MockEmbeddable._embedded_many = [ { "articles" => Reviewed::Article } ]
+      Reviewed::MockEmbeddable._embedded_many = [ { "articles" => "Reviewed::Article" } ]
     end
 
     context 'relationship exists in json' do
@@ -129,7 +120,7 @@ describe Reviewed::Embeddable do
     let(:mocked) { Reviewed::MockEmbeddable.new }
 
     before(:each) do
-      Reviewed::MockEmbeddable._embedded_one = [ { "article" => Reviewed::Article } ]
+      Reviewed::MockEmbeddable._embedded_one = [ { "article" => "Reviewed::Article" } ]
     end
 
     it 'objectifies' do
@@ -152,37 +143,13 @@ describe Reviewed::Embeddable do
         Reviewed::Embeddable.embedded_name("mock_embeddable").should eql("Reviewed::MockEmbeddable")
       end
     end
-  end
-
-  describe '.embedded_class' do
 
     context 'opts_name' do
 
       context 'valid' do
 
         it 'returns a class_constant' do
-          Reviewed::Embeddable.embedded_class("test", "Reviewed::MockEmbeddable")
-            .should eql(Reviewed::MockEmbeddable)
-        end
-      end
-
-      context 'invalid' do
-
-        it 'errors' do
-          expect {
-            Reviewed::Embeddable.embedded_class("test", "Reviewed::MockBad")
-          }.to raise_error
-        end
-      end
-    end
-
-    context 'name' do
-
-      context 'valid' do
-
-        it 'returns a class_constant' do
-          Reviewed::Embeddable.embedded_class("mock_embeddables")
-            .should eql(Reviewed::MockEmbeddable)
+          Reviewed::Embeddable.embedded_name("test", "Reviewed::MockEmbeddable").should eql("Reviewed::MockEmbeddable")
         end
       end
     end

--- a/spec/fixtures/vcr/Reviewed_Award/associations/articles/has_many_articles.yml
+++ b/spec/fixtures/vcr/Reviewed_Award/associations/articles/has_many_articles.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://the-guide-staging.herokuapp.com/api/v1/products/best-of-year
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Reviewed-Authorization:
+      - 38e397252ec670ec441733a95204f141
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - x-pagination, x-requested-with, x-requested-by, x-reviewed-authorization,
+        x-skip-cache, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1000'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 23 Oct 2013 20:26:06 GMT
+      Etag:
+      - '"e0aa021e21dddbd6d8cecec71e9cf564"'
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - dd3ae6ddb7599b7e77a8452fbc99d009
+      X-Runtime:
+      - '0.000745'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Record Not Found"}'
+    http_version: 
+  recorded_at: Wed, 23 Oct 2013 20:26:21 GMT
+- request:
+    method: get
+    uri: https://the-guide-staging.herokuapp.com/api/v1/awards/best-of-year
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Reviewed-Authorization:
+      - 38e397252ec670ec441733a95204f141
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - x-pagination, x-requested-with, x-requested-by, x-reviewed-authorization,
+        x-skip-cache, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1000'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 23 Oct 2013 20:26:36 GMT
+      Etag:
+      - '"e0aa021e21dddbd6d8cecec71e9cf564"'
+      Last-Modified:
+      - Tue, 22 Oct 2013 22:00:41 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 61a50ad8fd2bb86b35243656a36792fe
+      X-Runtime:
+      - '0.000745'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"50fef5cf85b7580c5100000c","created_at":"2013-01-22T20:25:51Z","updated_at":"2013-10-22T22:00:41Z","name":"Best
+        of Year","year":"2012","description":"It''s hard to know what to buy. There
+        are tons of electronics and home good our there with conflicting user reviews
+        everywhere you turn. How do you know which to trust? Our advice is simple:
+        let good science decide!  Our labs test hundred of products each year. Only
+        a precious few are great enough to earn a prestigious Best of Year award.
+        \n\nThe Best of Year awards are just that: the absolute best products of the
+        last calendar year. There are options at every price point, and lots of special
+        award categories to help you find just what you need.","slug":"best-of-year","resource_uri":"http://www.reviewed.com/awards/best-of-year","article_ids":[],"image_badge":{"small":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/small_leapaxlr8r-banner-companies.png","medium":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/medium_leapaxlr8r-banner-companies.png","large":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/large_leapaxlr8r-banner-companies.png"},"articles":[],"permissions":{"read":true,"create":false,"update":false,"destroy":false},"api_links":{"collection":{"rel":"/api/v1/awards","href":"https://the-guide-staging.herokuapp.com/api/v1/awards"},"resource":{"rel":"/api/v1/awards/50fef5cf85b7580c5100000c","href":"https://the-guide-staging.herokuapp.com/api/v1/awards/50fef5cf85b7580c5100000c"}}}'
+    http_version: 
+  recorded_at: Wed, 23 Oct 2013 20:26:51 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr/Reviewed_Award/associations/articles/returns_attachments_of_the_correct_class.yml
+++ b/spec/fixtures/vcr/Reviewed_Award/associations/articles/returns_attachments_of_the_correct_class.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://the-guide-staging.herokuapp.com/api/v1/products/best-of-year
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Reviewed-Authorization:
+      - 38e397252ec670ec441733a95204f141
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - x-pagination, x-requested-with, x-requested-by, x-reviewed-authorization,
+        x-skip-cache, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1000'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 23 Oct 2013 20:26:07 GMT
+      Etag:
+      - '"e0aa021e21dddbd6d8cecec71e9cf564"'
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 5413449a8c611eaec9856053f581cae0
+      X-Runtime:
+      - '0.001468'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Record Not Found"}'
+    http_version: 
+  recorded_at: Wed, 23 Oct 2013 20:26:22 GMT
+- request:
+    method: get
+    uri: https://the-guide-staging.herokuapp.com/api/v1/awards/best-of-year
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Reviewed-Authorization:
+      - 38e397252ec670ec441733a95204f141
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - x-pagination, x-requested-with, x-requested-by, x-reviewed-authorization,
+        x-skip-cache, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1000'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 23 Oct 2013 20:26:36 GMT
+      Etag:
+      - '"e0aa021e21dddbd6d8cecec71e9cf564"'
+      Last-Modified:
+      - Tue, 22 Oct 2013 22:00:41 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 0bb629f64ebf293f804af3a9db3f51c9
+      X-Runtime:
+      - '0.000919'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":"50fef5cf85b7580c5100000c","created_at":"2013-01-22T20:25:51Z","updated_at":"2013-10-22T22:00:41Z","name":"Best
+        of Year","year":"2012","description":"It''s hard to know what to buy. There
+        are tons of electronics and home good our there with conflicting user reviews
+        everywhere you turn. How do you know which to trust? Our advice is simple:
+        let good science decide!  Our labs test hundred of products each year. Only
+        a precious few are great enough to earn a prestigious Best of Year award.
+        \n\nThe Best of Year awards are just that: the absolute best products of the
+        last calendar year. There are options at every price point, and lots of special
+        award categories to help you find just what you need.","slug":"best-of-year","resource_uri":"http://www.reviewed.com/awards/best-of-year","article_ids":[],"image_badge":{"small":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/small_leapaxlr8r-banner-companies.png","medium":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/medium_leapaxlr8r-banner-companies.png","large":"http://reviewed-staging.s3.amazonaws.com/uploads/award/image_badge/50fef5cf85b7580c5100000c/large_leapaxlr8r-banner-companies.png"},"articles":[],"permissions":{"read":true,"create":false,"update":false,"destroy":false},"api_links":{"collection":{"rel":"/api/v1/awards","href":"https://the-guide-staging.herokuapp.com/api/v1/awards"},"resource":{"rel":"/api/v1/awards/50fef5cf85b7580c5100000c","href":"https://the-guide-staging.herokuapp.com/api/v1/awards/50fef5cf85b7580c5100000c"}}}'
+    http_version: 
+  recorded_at: Wed, 23 Oct 2013 20:26:51 GMT
+recorded_with: VCR 2.4.0

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -16,7 +16,7 @@ describe Reviewed::Product do
       end
 
       it 'no longer has_many :attachments' do
-        Reviewed::Product._embedded_many.should_not include({"attachments"=>Reviewed::Attachment})
+        Reviewed::Product._embedded_many.should_not include({"attachments"=>"Reviewed::Attachment"})
       end
 
       it 'returns attachments of the correct class' do
@@ -50,7 +50,7 @@ describe Reviewed::Product do
     end
 
     it 'has_many :manufacturer_specs' do
-      Reviewed::Product._embedded_many.should include({"manufacturer_specs"=>Reviewed::ManufacturerSpec})
+      Reviewed::Product._embedded_many.should include({"manufacturer_specs"=>"Reviewed::ManufacturerSpec"})
     end
 
     it 'returns attachments of the correct class' do


### PR DESCRIPTION
now storing internal mappings as strings instead of classes
allows us to get around explicit requires at declaration time
and the dependency / circular dependency issues that come with that

required for adding articles association to award...
