### PR TITLE
Use new faraday API for registering middlewares.

### DIFF
--- a/lib/faraday/api_key.rb
+++ b/lib/faraday/api_key.rb
@@ -11,4 +11,4 @@ module Faraday
   end
 end
 
-Faraday.register_middleware :request, api_key: Faraday::ApiKey
+Faraday::Request.register_middleware(api_key: Faraday::ApiKey)

--- a/lib/faraday/errors.rb
+++ b/lib/faraday/errors.rb
@@ -11,4 +11,4 @@ module Faraday
   end
 end
 
-Faraday.register_middleware :response, errors: Faraday::Errors
+Faraday::Response.register_middleware(errors: Faraday::Errors)

--- a/lib/reviewed/version.rb
+++ b/lib/reviewed/version.rb
@@ -1,4 +1,4 @@
 module Reviewed
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
Faraday 0.9.0 changed the API for registering middlewares.  This made
a lot of people mad but sinces its not 1.0 yet they basically said
"whatever" which is perfectly valid.  Since commit a9a08c12 unpegged
faraday new users (Timur) are getting undefined method "register_middleware"
errors.  This should fix this issue.

https://www.pivotaltracker.com/story/show/71784926
